### PR TITLE
Driver Timer

### DIFF
--- a/src/drivers/timer/i8254.h
+++ b/src/drivers/timer/i8254.h
@@ -1,0 +1,41 @@
+#ifndef _IO_I8254_
+#define _IO_I8254_
+
+/**
+ * @file i8254.h
+ * @brief Intel 8254 Programmable Interval Timer (PIT) register and control definitions
+ */
+
+#include "../utils.h"
+#include "stdbool.h"
+#include "stdint.h"
+
+#define TIMER_0_REG    0x40                        /** @brief Channel 0 data port */
+#define TIMER_1_REG    0x41                        /** @brief Channel 1 data port */
+#define TIMER_2_REG    0x42                        /** @brief Channel 2 data port */
+#define TIMER_CTRL_REG 0x43                        /** @brief Control word port */
+
+#define CTRL_SELECT_TIMER_0 0x00                   /** @brief Select timer channel 0 */
+#define CTRL_SELECT_TIMER_1 BIT(6)                 /** @brief Select timer channel 1 */
+#define CTRL_SELECT_TIMER_2 BIT(7)                 /** @brief Select timer channel 2 */
+
+#define CTRL_LSB          BIT(4)                   /** @brief Input least significant byte only */
+#define CTRL_MSB          BIT(5)                   /** @brief Input most significant byte only */
+#define CTRL_LSB_MSB      (BIT(5) | BIT(4))        /** @brief Input least then most significant byte */
+#define CTRL_LSB_MSB_MASK (BIT(5) | BIT(4))        /** @brief Input mode mask */
+
+#define CTRL_MODE_0     0x00                       /** @brief Mode 0: Interrupt on terminal count */
+#define CTRL_MODE_1     BIT(1)                     /** @brief Mode 1: Hardware re-triggerable one-shot */
+#define CTRL_MODE_2     BIT(2)                     /** @brief Mode 2: Rate generator */
+#define CTRL_MODE_2_ALT (BIT(3) | BIT(2))          /** @brief Mode 2: Rate generator | Alternative form */
+#define CTRL_MODE_3     (BIT(2) | BIT(1))          /** @brief Mode 3: Square wave generator */
+#define CTRL_MODE_3_ALT (BIT(3) | BIT(2) | BIT(1)) /** @brief Mode 3: Square wave generator | Alternative form*/
+#define CTRL_MODE_4     BIT(3)                     /** @brief Mode 4: Software triggered strobe */
+#define CTRL_MODE_5     (BIT(3) | BIT(1))          /** @brief Mode 5: Hardware triggered strobe */
+#define CTRL_MODE_MASK  (BIT(3) | BIT(2) | BIT(1)) /** @brief Couting mode mask */
+
+#define CTRL_NOT_BCD  0x00                         /** @brief 16-bit binary counter */
+#define CTRL_BCD      BIT(0)                       /** @brief Four-digit BCD counter */
+#define CTRL_BCD_MASK BIT(0)                       /** @brief BCD option mask */
+
+#endif                                             // _IO_I8254_

--- a/src/drivers/timer/i8254.h
+++ b/src/drivers/timer/i8254.h
@@ -10,6 +10,7 @@
 #include "stdbool.h"
 #include "stdint.h"
 
+#define TIMER_IRQ_LINE  0                          /** @brief Timer IRQ Line number */
 #define TIMER_FREQUENCY 1193182                    /** @brief Clock frequency of timer counter */
 
 #define TIMER_0_REG    0x40                        /** @brief Channel 0 data port */

--- a/src/drivers/timer/i8254.h
+++ b/src/drivers/timer/i8254.h
@@ -10,6 +10,8 @@
 #include "stdbool.h"
 #include "stdint.h"
 
+#define TIMER_FREQUENCY 1193182                    /** @brief Clock frequency of timer counter */
+
 #define TIMER_0_REG    0x40                        /** @brief Channel 0 data port */
 #define TIMER_1_REG    0x41                        /** @brief Channel 1 data port */
 #define TIMER_2_REG    0x42                        /** @brief Channel 2 data port */

--- a/src/drivers/timer/i8254.h
+++ b/src/drivers/timer/i8254.h
@@ -10,8 +10,9 @@
 #include "stdbool.h"
 #include "stdint.h"
 
-#define TIMER_IRQ_LINE  0                          /** @brief Timer IRQ Line number */
-#define TIMER_FREQUENCY 1193182                    /** @brief Clock frequency of timer counter */
+#define TIMER_IRQ_LINE      0                      /** @brief Timer IRQ Line number */
+#define TIMER_FREQUENCY     1193182                /** @brief Clock frequency of timer counter */
+#define TIMER_MIN_FREQUENCY 19                     /** @brief Timer minumum frequency */
 
 #define TIMER_0_REG    0x40                        /** @brief Channel 0 data port */
 #define TIMER_1_REG    0x41                        /** @brief Channel 1 data port */

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -40,7 +40,7 @@ Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status
         break;
 
     case tsf_mode:
-        RETURN_IF_ERROR(timer_status_to_couting_mode(status, &coutingMode));
+        RETURN_IF_ERROR(timer_status_to_counting_mode(status, &coutingMode));
         value.count_mode = coutingMode;
         break;
 
@@ -73,7 +73,7 @@ Result timer_set_frequency_alt(Timer timer, uint32_t freq) {
     // Store current state not to lose
     TimerCountingMode countingMode;
     TimerBCDMode      bcdMode;
-    RETURN_IF_ERROR(timer_status_to_couting_mode(status, &countingMode));
+    RETURN_IF_ERROR(timer_status_to_counting_mode(status, &countingMode));
     RETURN_IF_ERROR(timer_status_to_bsc(status, &bcdMode));
 
     // Create new control word

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -58,7 +58,7 @@ Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status
 
 Result timer_set_frequency_alt(Timer timer, uint32_t freq) {
     // Calculate counter value for the given frequency
-    if (freq < 19 || freq > TIMER_FREQUENCY) return RES_INVALID_ARGUMENT;
+    if (freq < TIMER_MIN_FREQUENCY || freq > TIMER_FREQUENCY) return RES_INVALID_ARGUMENT;
     uint16_t counterValue = TIMER_FREQUENCY / freq;
 
     // Get counter initial value as separate bytes

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -1,4 +1,4 @@
-#include "./timer.h"
+#include "timer.h"
 
 Result timer_get_conf_alt(Timer timer, TimerStatus *status) {
     if (status == NULL) return RES_NULL_POINTER;
@@ -55,7 +55,41 @@ Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status
 }
 
 Result timer_set_frequency_alt(Timer timer, uint32_t freq) {
-    // TODO Finish
+    // Calculate counter value for the given frequency
+    if (freq < 19 || freq > TIMER_FREQUENCY) return RES_INVALID_ARGUMENT;
+    uint16_t counterValue = TIMER_FREQUENCY / freq;
+
+    // Get counter initial value as separate bytes
+    uint8_t counterValueMSB, counterValueLSB;
+    RETURN_IF_ERROR(util_get_MSB_alt(counterValue, &counterValueMSB));
+    RETURN_IF_ERROR(util_get_LSB_alt(counterValue, &counterValueLSB));
+
+    // Read timer current status
+    TimerStatus status;
+    RETURN_IF_ERROR(timer_get_conf_alt(timer, &status));
+
+    // Store current state not to lose
+    TimerCountingMode countingMode;
+    TimerBCDMode      bcdMode;
+    RETURN_IF_ERROR(timer_status_to_couting_mode(status, &countingMode));
+    RETURN_IF_ERROR(timer_status_to_bsc(status, &bcdMode));
+
+    // Create new control word
+    TimerCtrlWord word;
+    RETURN_IF_ERROR(timer_ctrl_word(timer, LSB_MSB, countingMode, bcdMode, &word));
+
+    //! Hack to give what is expected to LCOM
+    // Some options for the TimerCountingMode have multiple different 
+    // representations even though it should always be only one
+    // this code keeps the representation stored on the register
+    if (status & BIT(3)) word |= BIT(3);
+
+    // Update counter with new control word
+    RETURN_IF_ERROR(util_sys_outb(TIMER_CTRL_REG, word));
+
+    // Write counter initial bytes to timer
+    RETURN_IF_ERROR(util_sys_outb(timer_to_reg(timer), counterValueLSB));
+    RETURN_IF_ERROR(util_sys_outb(timer_to_reg(timer), counterValueMSB));
 
     return RES_OK;
 }

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -1,24 +1,29 @@
 #include "./timer.h"
 
-Result timer_get_conf(Timer timer, TimerStatus *status) {
+Result timer_get_conf_alt(Timer timer, TimerStatus *status) {
+    if (status == NULL) return RES_NULL_POINTER;
+
     TimerCtrlWord command = timer_readback_command(false, true, timer == TIMER_0, timer == TIMER_1, timer == TIMER_2);
-    RETURN_ON_ERROR(util_sys_outb(TIMER_CTRL_REG, command));
+    RETURN_IF_ERROR(util_sys_outb(TIMER_CTRL_REG, command));
 
     TimerStatus temp_status;
-    RETURN_ON_ERROR(util_sys_inb(timer_to_reg(timer), &temp_status));
+    RETURN_IF_ERROR(util_sys_inb_alt(timer_to_reg(timer), &temp_status));
     *status = temp_status;
 
     return RES_OK;
 }
 
-Result timer_display_conf(Timer timer, TimerStatus status, enum timer_status_field field) {
+Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status_field field) {
     union timer_status_field_val value;
+
+    TimerInitMode     initMode;
+    TimerCountingMode coutingMode;
+    TimerBCDMode      bcdMode;
 
     switch (field) {
     case tsf_all: value.byte = status; break;
 
     case tsf_initial:
-        TimerInitMode initMode;
         if (IS_ERROR(timer_status_to_init_mode(status, &initMode))) {
             value.in_mode = INVAL_val;
             break;
@@ -33,19 +38,24 @@ Result timer_display_conf(Timer timer, TimerStatus status, enum timer_status_fie
         break;
 
     case tsf_mode:
-        TimerCountingMode coutingMode;
         RETURN_IF_ERROR(timer_status_to_couting_mode(status, &coutingMode));
         value.count_mode = coutingMode;
         break;
 
     case tsf_base:
-        TimerBCDMode bcdMode;
         RETURN_IF_ERROR(timer_status_to_bsc(status, &bcdMode));
         value.bcd = bcdMode;
+        break;
 
     default: return RES_INVALID_ARGUMENT;
     }
 
     if (IS_ERROR(timer_print_config(timer, field, value))) return RES_ERROR;
+    return RES_OK;
+}
+
+Result timer_set_frequency_alt(Timer timer, uint32_t freq) {
+    // TODO Finish
+
     return RES_OK;
 }

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -5,6 +5,7 @@
 #include "../../utils/result.h"
 #include "../utils.h"
 #include "i8254.h"
+#include "lcom/lcf.h"
 #include "lcom/timer.h"
 
 /**
@@ -108,8 +109,8 @@ static inline Result timer_ctrl_word(
  * @param   t_2    ...
  * @return  Control word for readback.
  */
-static inline TimerCtrlWord timer_create_readback_command(bool count, bool status, bool t_0, bool t_1, bool t_2) {
-    uint8_t word = 0x00;
+static inline TimerCtrlWord timer_readback_command(bool count, bool status, bool t_0, bool t_1, bool t_2) {
+    uint8_t word = BIT(7) | BIT(6);
 
     if (!count) word |= BIT(5);
     if (!status) word |= BIT(4);
@@ -134,7 +135,7 @@ static inline Result timer_status_to_init_mode(TimerStatus status, TimerInitMode
     case CTRL_LSB    : *initMode = LSB; break;
     case CTRL_MSB    : *initMode = MSB; break;
     case CTRL_LSB_MSB: *initMode = LSB_MSB; break;
-    default          : RES_INVALID_ARGUMENT;
+    default          : return RES_INVALID_ARGUMENT;
     }
 
     return RES_OK;
@@ -191,7 +192,7 @@ static inline Result timer_status_to_bsc(TimerStatus status, TimerBCDMode *bcdMo
  * @param   status  Out: the returned status byte.
  * @return  RES_OK on success or an error code on failure.
  */
-Result timer_get_conf(Timer timer, TimerStatus *status);
+Result timer_get_conf_alt(Timer timer, TimerStatus *status);
 
 /**
  * @brief   Displays a specific field of a timer’s status.
@@ -200,6 +201,8 @@ Result timer_get_conf(Timer timer, TimerStatus *status);
  * @param   field   Which field to display (tsf_all, tsf_initial, etc.).
  * @return  RES_OK on success or an error code on failure.
  */
-Result timer_display_conf(Timer timer, TimerStatus status, enum timer_status_field field);
+Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status_field field);
+
+Result timer_set_frequency_alt(Timer timer, uint32_t freq);
 
 #endif // _IO_TIMER_

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -1,0 +1,205 @@
+#ifndef _IO_TIMER_
+#define _IO_TIMER_
+
+// Timer - Device Driver
+#include "../../utils/result.h"
+#include "../utils.h"
+#include "i8254.h"
+#include "lcom/timer.h"
+
+/**
+ * @enum  Timer
+ * @brief Identifies one of the three PIT timer channels.
+ */
+typedef enum { TIMER_0 = 0, TIMER_1, TIMER_2 } Timer;
+
+/**
+ * @enum  TimerInitMode
+ * @brief Specifies how the timer count is loaded.
+ */
+typedef enum { LSB = 0, MSB, LSB_MSB } TimerInitMode;
+
+/**
+ * @enum  TimerCountingMode
+ * @brief Defines the counting/operating mode of the PIT.
+ */
+typedef enum { MODE_0 = 0, MODE_1, MODE_2, MODE_3, MODE_4, MODE_5 } TimerCountingMode;
+
+/**
+ * @enum  TimerBCDMode
+ * @brief Selects binary or BCD counter format.
+ */
+typedef enum { NOT_BCD_MODE = 0, BCD_MODE } TimerBCDMode;
+
+/**
+ * @typedef TimerStatus
+ * @brief   Raw status byte returned by the PIT.
+ */
+typedef uint8_t TimerStatus;
+
+/**
+ * @typedef TimerCtrlWord
+ * @brief   Control word used to configure the PIT.
+ */
+typedef uint8_t TimerCtrlWord;
+
+/**
+ * @brief   Get the I/O port address for the specified timer channel.
+ * @param   timer  The timer channel (TIMER_0..TIMER_2).
+ * @return  I/O port register for the timer.
+ */
+static inline uint8_t timer_to_reg(Timer timer) { return TIMER_0_REG + timer; }
+
+/**
+ * @brief   Build a PIT control word to set mode and format.
+ * @param   timer        Channel to configure.
+ * @param   initMode     Load mode (LSB, MSB, LSB_MSB).
+ * @param   countingMode Counting/operation mode.
+ * @param   bcdMode      Binary or BCD counting.
+ * @param   word         Out: assembled control word.
+ * @return  RES_OK or error code.
+ */
+static inline Result timer_ctrl_word(
+    Timer timer, TimerInitMode initMode, TimerCountingMode countingMode, TimerBCDMode bcdMode, TimerCtrlWord *word
+) {
+    if (word == NULL) return RES_NULL_POINTER;
+    TimerCtrlWord temp_word = 0x00;
+
+    switch (timer) {
+    case TIMER_0: temp_word |= CTRL_SELECT_TIMER_0; break;
+    case TIMER_1: temp_word |= CTRL_SELECT_TIMER_1; break;
+    case TIMER_2: temp_word |= CTRL_SELECT_TIMER_2; break;
+    default     : return RES_INVALID_ARGUMENT;
+    }
+
+    switch (initMode) {
+    case LSB    : temp_word |= CTRL_LSB; break;
+    case MSB    : temp_word |= CTRL_MSB; break;
+    case LSB_MSB: temp_word |= CTRL_LSB_MSB; break;
+    default     : return RES_INVALID_ARGUMENT;
+    }
+
+    switch (countingMode) {
+    case MODE_0: temp_word |= CTRL_MODE_0; break;
+    case MODE_1: temp_word |= CTRL_MODE_1; break;
+    case MODE_2: temp_word |= CTRL_MODE_2; break;
+    case MODE_3: temp_word |= CTRL_MODE_3; break;
+    case MODE_4: temp_word |= CTRL_MODE_4; break;
+    case MODE_5: temp_word |= CTRL_MODE_5; break;
+    default    : return RES_INVALID_ARGUMENT;
+    }
+
+    switch (bcdMode) {
+    case NOT_BCD_MODE: temp_word |= CTRL_NOT_BCD; break;
+    case BCD_MODE    : temp_word |= CTRL_BCD; break;
+    default          : return RES_INVALID_ARGUMENT;
+    }
+
+    *word = temp_word;
+    return RES_OK;
+}
+
+/**
+ * @brief   Create a readback command to query count/status.
+ * @param   count  true to latch count, false to ignore.
+ * @param   status true to latch status, false to ignore.
+ * @param   t_0    true to select timer0, etc.
+ * @param   t_1    ...
+ * @param   t_2    ...
+ * @return  Control word for readback.
+ */
+static inline TimerCtrlWord timer_create_readback_command(bool count, bool status, bool t_0, bool t_1, bool t_2) {
+    uint8_t word = 0x00;
+
+    if (!count) word |= BIT(5);
+    if (!status) word |= BIT(4);
+
+    if (t_2) word |= BIT(3);
+    if (t_1) word |= BIT(2);
+    if (t_0) word |= BIT(1);
+
+    return word;
+}
+
+/**
+ * @brief   Decode init mode from a status byte.
+ * @param   status     Raw status byte.
+ * @param   initMode   Out: decoded init mode.
+ * @return  RES_OK or error code.
+ */
+static inline Result timer_status_to_init_mode(TimerStatus status, TimerInitMode *initMode) {
+    if (initMode == NULL) return RES_NULL_POINTER;
+
+    switch (status & CTRL_LSB_MSB_MASK) {
+    case CTRL_LSB    : *initMode = LSB; break;
+    case CTRL_MSB    : *initMode = MSB; break;
+    case CTRL_LSB_MSB: *initMode = LSB_MSB; break;
+    default          : RES_INVALID_ARGUMENT;
+    }
+
+    return RES_OK;
+}
+
+/**
+ * @brief   Decode counting mode from a status byte.
+ * @param   status       Raw status byte.
+ * @param   coutingMode  Out: decoded counting mode.
+ * @return  RES_OK or error code.
+ */
+static inline Result timer_status_to_couting_mode(TimerStatus status, TimerCountingMode *coutingMode) {
+    if (coutingMode == NULL) return RES_NULL_POINTER;
+
+    switch (status & CTRL_MODE_MASK) {
+    case CTRL_MODE_0: *coutingMode = MODE_0; break;
+    case CTRL_MODE_1: *coutingMode = MODE_1; break;
+    case CTRL_MODE_4: *coutingMode = MODE_4; break;
+    case CTRL_MODE_5: *coutingMode = MODE_5; break;
+
+    case CTRL_MODE_2:
+    case CTRL_MODE_2_ALT: *coutingMode = MODE_2; break;
+
+    case CTRL_MODE_3:
+    case CTRL_MODE_3_ALT: *coutingMode = MODE_3; break;
+
+    default: return RES_INVALID_ARGUMENT;
+    }
+
+    return RES_OK;
+}
+
+/**
+ * @brief   Decode BCD/binary mode from a status byte.
+ * @param   status   Raw status byte.
+ * @param   bcdMode  Out: decoded BCD mode.
+ * @return  RES_OK or error code.
+ */
+static inline Result timer_status_to_bsc(TimerStatus status, TimerBCDMode *bcdMode) {
+    if (bcdMode == NULL) return RES_NULL_POINTER;
+
+    switch (status & CTRL_BCD_MASK) {
+    case CTRL_BCD    : *bcdMode = BCD_MODE; break;
+    case CTRL_NOT_BCD: *bcdMode = NOT_BCD_MODE; break;
+    default          : return RES_INVALID_ARGUMENT;
+    }
+
+    return RES_OK;
+}
+
+/**
+ * @brief   Reads the current configuration (status byte) of a timer channel.
+ * @param   timer   The timer channel to query.
+ * @param   status  Out: the returned status byte.
+ * @return  RES_OK on success or an error code on failure.
+ */
+Result timer_get_conf(Timer timer, TimerStatus *status);
+
+/**
+ * @brief   Displays a specific field of a timer’s status.
+ * @param   timer   The timer channel.
+ * @param   status  The status byte obtained via timer_get_conf.
+ * @param   field   Which field to display (tsf_all, tsf_initial, etc.).
+ * @return  RES_OK on success or an error code on failure.
+ */
+Result timer_display_conf(Timer timer, TimerStatus status, enum timer_status_field field);
+
+#endif // _IO_TIMER_

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -188,21 +188,27 @@ static inline Result timer_status_to_bsc(TimerStatus status, TimerBCDMode *bcdMo
 
 /**
  * @brief   Reads the current configuration (status byte) of a timer channel.
- * @param   timer   The timer channel to query.
- * @param   status  Out: the returned status byte.
+ * @param   timer   The timer channel to query (TIMER_0..TIMER_2).
+ * @param   status  Out: pointer to where the returned status byte will be stored.
  * @return  RES_OK on success or an error code on failure.
  */
 Result timer_get_conf_alt(Timer timer, TimerStatus *status);
 
 /**
  * @brief   Displays a specific field of a timer’s status.
- * @param   timer   The timer channel.
- * @param   status  The status byte obtained via timer_get_conf.
- * @param   field   Which field to display (tsf_all, tsf_initial, etc.).
+ * @param   timer   The timer channel (TIMER_0..TIMER_2).
+ * @param   status  The status byte obtained via timer_get_conf_alt().
+ * @param   field   Which field to display (tsf_all, tsf_initial, tsf_mode, tsf_base).
  * @return  RES_OK on success or an error code on failure.
  */
 Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status_field field);
 
+/**
+ * @brief   Changes the operating frequency of a timer channel.
+ * @param   timer  The timer channel to configure (TIMER_0..TIMER_2).
+ * @param   freq   Desired timer operating frequency (Hz).
+ * @return  RES_OK on success or an error code on failure.
+ */
 Result timer_set_frequency_alt(Timer timer, uint32_t freq);
 
 #endif // _IO_TIMER_

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -144,23 +144,23 @@ static inline Result timer_status_to_init_mode(TimerStatus status, TimerInitMode
 /**
  * @brief   Decode counting mode from a status byte.
  * @param   status       Raw status byte.
- * @param   coutingMode  Out: decoded counting mode.
+ * @param   countingMode  Out: decoded counting mode.
  * @return  RES_OK or error code.
  */
-static inline Result timer_status_to_couting_mode(TimerStatus status, TimerCountingMode *coutingMode) {
-    if (coutingMode == NULL) return RES_NULL_POINTER;
+static inline Result timer_status_to_counting_mode(TimerStatus status, TimerCountingMode *countingMode) {
+    if (countingMode == NULL) return RES_NULL_POINTER;
 
     switch (status & CTRL_MODE_MASK) {
-    case CTRL_MODE_0: *coutingMode = MODE_0; break;
-    case CTRL_MODE_1: *coutingMode = MODE_1; break;
-    case CTRL_MODE_4: *coutingMode = MODE_4; break;
-    case CTRL_MODE_5: *coutingMode = MODE_5; break;
+    case CTRL_MODE_0: *countingMode = MODE_0; break;
+    case CTRL_MODE_1: *countingMode = MODE_1; break;
+    case CTRL_MODE_4: *countingMode = MODE_4; break;
+    case CTRL_MODE_5: *countingMode = MODE_5; break;
 
     case CTRL_MODE_2:
-    case CTRL_MODE_2_ALT: *coutingMode = MODE_2; break;
+    case CTRL_MODE_2_ALT: *countingMode = MODE_2; break;
 
     case CTRL_MODE_3:
-    case CTRL_MODE_3_ALT: *coutingMode = MODE_3; break;
+    case CTRL_MODE_3_ALT: *countingMode = MODE_3; break;
 
     default: return RES_INVALID_ARGUMENT;
     }

--- a/src/drivers/timer/timer.h
+++ b/src/drivers/timer/timer.h
@@ -211,4 +211,17 @@ Result timer_display_conf_alt(Timer timer, TimerStatus status, enum timer_status
  */
 Result timer_set_frequency_alt(Timer timer, uint32_t freq);
 
+/**
+ * @brief   Subscribes to timer interrupts.
+ * @param   bit_no  Out: pointer to store the IRQ bit number for the timer.
+ * @return  RES_OK on success or an error code on failure.
+ */
+Result timer_subscribe_int_alt(uint8_t *bit_no);
+
+/**
+ * @brief   Unsubscribes from timer interrupts.
+ * @return  RES_OK on success or an error code on failure.
+ */
+Result timer_unsubscribe_int_alt();
+
 #endif // _IO_TIMER_

--- a/src/drivers/utils.c
+++ b/src/drivers/utils.c
@@ -1,6 +1,6 @@
 #include "utils.h"
-#include "stdint.h"
 #include "lcom/lcf.h"
+#include "stdint.h"
 
 Result util_sys_outb(uint32_t port, uint8_t byte) {
     if (sys_outb(port, byte)) return RES_IO_ERROR;
@@ -15,5 +15,17 @@ Result util_sys_inb_alt(uint32_t port, uint8_t *byte) {
     if (sys_inb(port, &value)) return RES_IO_ERROR;
     *byte = (uint8_t)value;
 
+    return RES_OK;
+}
+
+Result util_get_LSB_alt(uint16_t val, uint8_t *lsb) {
+    if (lsb == NULL) return RES_NULL_POINTER;
+    *lsb = val & 0xFF;
+    return RES_OK;
+}
+
+Result util_get_MSB_alt(uint16_t val, uint8_t *msb) {
+    if (msb == NULL) return RES_NULL_POINTER;
+    *msb = (val >> 8) & 0xFF;
     return RES_OK;
 }

--- a/src/drivers/utils.c
+++ b/src/drivers/utils.c
@@ -1,0 +1,19 @@
+#include "utils.h"
+#include "stdint.h"
+#include "lcom/lcf.h"
+
+Result util_sys_outb(uint32_t port, uint8_t byte) {
+    if (sys_outb(port, byte)) return RES_IO_ERROR;
+    return RES_OK;
+}
+
+Result util_sys_inb_alt(uint32_t port, uint8_t *byte) {
+    if (byte == NULL) return RES_NULL_POINTER;
+
+    uint32_t value;
+
+    if (sys_inb(port, &value)) return RES_IO_ERROR;
+    *byte = (uint8_t)value;
+
+    return RES_OK;
+}

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -1,0 +1,25 @@
+#ifndef _IO_UTILS_
+#define _IO_UTILS_
+
+// IO Utils
+#include "../utils/result.h"
+#include "minix/syslib.h"
+#include "stdint.h"
+
+#define BIT(n) (1 << n)
+
+Result util_sys_outb(int32_t port, u8_t byte) {
+    if (sys_outb(port, byte)) return RES_IO_ERROR;
+    return RES_OK;
+}
+
+Result util_sys_inb(int32_t port, u8_t *byte) {
+    uint32_t value;
+
+    if (sys_inb(port, &value)) return RES_IO_ERROR;
+    *byte = (uint8_t)value;
+
+    return RES_OK;
+}
+
+#endif // _IO_UTILS_

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -1,3 +1,8 @@
+/**
+ * @file drivers/utils.h
+ * @brief Utility functions and macros for I/O operations and data manipulation.
+ */
+
 #ifndef _IO_UTILS_
 #define _IO_UTILS_
 
@@ -5,10 +10,43 @@
 #include "../utils/result.h"
 #include "stdint.h"
 
+/**
+ * @brief Create a bit mask with bit n set.
+ * @param n The bit position to set (0-based).
+ */
 #define BIT(n) (1 << n)
 
+/**
+ * @brief Write a byte to the specified I/O port.
+ * @param port The I/O port address.
+ * @param byte The byte value to write.
+ * @return RES_OK on success, otherwise an error code.
+ */
 Result util_sys_outb(uint32_t port, uint8_t byte);
 
+/**
+ * @brief Read a byte from the specified I/O port.
+ * @param port The I/O port address.
+ * @param byte Pointer to store the read byte.
+ * @return RES_OK on success, RES_NULL_POINTER if byte is NULL,
+ *         or RES_IO_ERROR on I/O failure.
+ */
 Result util_sys_inb_alt(uint32_t port, uint8_t *byte);
+
+/**
+ * @brief Extract the least significant byte from a 16-bit value.
+ * @param val The 16-bit input value.
+ * @param lsb Pointer to store the least significant byte.
+ * @return RES_OK on success, or RES_NULL_POINTER if lsb is NULL.
+ */
+Result util_get_LSB_alt(uint16_t val, uint8_t *lsb);
+
+/**
+ * @brief Extract the most significant byte from a 16-bit value.
+ * @param val The 16-bit input value.
+ * @param msb Pointer to store the most significant byte.
+ * @return RES_OK on success, or RES_NULL_POINTER if msb is NULL.
+ */
+Result util_get_MSB_alt(uint16_t val, uint8_t *msb);
 
 #endif // _IO_UTILS_

--- a/src/drivers/utils.h
+++ b/src/drivers/utils.h
@@ -3,23 +3,12 @@
 
 // IO Utils
 #include "../utils/result.h"
-#include "minix/syslib.h"
 #include "stdint.h"
 
 #define BIT(n) (1 << n)
 
-Result util_sys_outb(int32_t port, u8_t byte) {
-    if (sys_outb(port, byte)) return RES_IO_ERROR;
-    return RES_OK;
-}
+Result util_sys_outb(uint32_t port, uint8_t byte);
 
-Result util_sys_inb(int32_t port, u8_t *byte) {
-    uint32_t value;
-
-    if (sys_inb(port, &value)) return RES_IO_ERROR;
-    *byte = (uint8_t)value;
-
-    return RES_OK;
-}
+Result util_sys_inb_alt(uint32_t port, uint8_t *byte);
 
 #endif // _IO_UTILS_

--- a/src/labs/Makefile
+++ b/src/labs/Makefile
@@ -1,0 +1,19 @@
+# name of the program (Minix service)
+PROG=lab2
+
+.PATH: ${.CURDIR}/../drivers
+.PATH: ${.CURDIR}/../drivers/timer
+
+# source code files to be compiled
+SRCS = lab2.c utils.c timer.c
+
+# additional compilation flags
+# "-Wall -Wextra -Werror -I . -std=c11 -Wno-unused-parameter" are already set
+CFLAGS += -pedantic -O3 -march=native -mtune=native
+
+# list of library dependencies (for Lab 2, only LCF library)
+DPADD += ${LIBLCF}
+LDADD += -llcf
+
+# include LCOM's makefile that does all the "heavy lifting"
+.include <minix.lcom.mk> 

--- a/src/labs/lab2.c
+++ b/src/labs/lab2.c
@@ -36,10 +36,8 @@ int(timer_test_read_config)(uint8_t timer, enum timer_status_field field) {
 }
 
 int(timer_test_time_base)(uint8_t timer, uint32_t freq) {
-    /* To be implemented by the students */
-    printf("%s is not yet implemented!\n", __func__);
-
-    return 1;
+    RETURN_IF_ERROR(timer_set_frequency_alt(timer, freq));
+    return RES_OK;
 }
 
 int(timer_test_int)(uint8_t time) {

--- a/src/labs/lab2.c
+++ b/src/labs/lab2.c
@@ -1,0 +1,50 @@
+#include "../drivers/timer/timer.h"
+#include "../utils/result.h"
+#include <lcom/lab2.h>
+#include <lcom/lcf.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[]) {
+    // sets the language of LCF messages (can be either EN-US or PT-PT)
+    lcf_set_language("EN-US");
+
+    // enables to log function invocations that are being "wrapped" by LCF
+    // [comment this out if you don't want/need it]
+    lcf_trace_calls("/home/lcom/labs/trace.txt");
+
+    // enables to save the output of printf function calls on a file
+    // [comment this out if you don't want/need it]
+    lcf_log_output("/home/lcom/labs/output.txt");
+
+    // handles control over to LCF
+    // [LCF handles command line arguments and invokes the right function]
+    lcf_start(argc, argv);
+
+    // LCF clean up tasks
+    // [must be the last statement before return]
+    lcf_cleanup();
+
+    return 0;
+}
+
+int(timer_test_read_config)(uint8_t timer, enum timer_status_field field) {
+    TimerStatus status;
+    RETURN_IF_ERROR(timer_get_conf_alt(timer, &status));
+    RETURN_IF_ERROR(timer_display_conf_alt(timer, status, field));
+    return RES_OK;
+}
+
+int(timer_test_time_base)(uint8_t timer, uint32_t freq) {
+    /* To be implemented by the students */
+    printf("%s is not yet implemented!\n", __func__);
+
+    return 1;
+}
+
+int(timer_test_int)(uint8_t time) {
+    /* To be implemented by the students */
+    printf("%s is not yet implemented!\n", __func__);
+
+    return 1;
+}

--- a/src/labs/lab2.h
+++ b/src/labs/lab2.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "lcom/timer.h"
+#include <stdint.h>
+
+/**
+ * @brief Tests display of timer config
+ *
+ * Just calls timer_get_conf_alt() followed by timer_display_conf_alt()
+ *
+ * @param timer Timer whose config to read (Ranges from 0 to 2)
+ * @param field Configuration field to display
+ * @return Return 0 upon success and non-zero otherwise
+ */
+int(timer_test_read_config)(uint8_t timer, enum timer_status_field field);
+
+/**
+ * @brief Tests change of Timer O interrupt frequency
+ *
+ * Programs Timer 0 to generate interrupts with input frequency
+ *
+ * @param timer Timer whose time-base should be changed (Ranges from 0 to 2)
+ * @param freq  Frequency of interrupts to generate
+ * @return Return 0 upon success and non-zero otherwise
+ */
+int(timer_test_time_base)(uint8_t timer, uint32_t freq);
+
+/**
+ * @brief Tests Timer 0 interrupt handling
+ *
+ * Subscribes Timer 0 interrupts and prints a message once
+ *  per second for the specified time interval in seconds
+ *
+ * @param time Length, in seconds, of time interval while interrupts are subscribed
+ * @return Return 0 upon success and non-zero otherwise
+ */
+int(timer_test_int)(uint8_t time);

--- a/src/utils/result.h
+++ b/src/utils/result.h
@@ -1,0 +1,48 @@
+#ifndef _T_RESULT_
+#define _T_RESULT_
+
+/**
+ * @file result.h
+ * @brief Defines the Result enum and helper macros for error handling.
+ */
+
+/**
+ * @enum Result
+ * @brief Status codes indicating success or specific error conditions.
+ */
+typedef enum {
+    RES_OK = 0,           // Success, no error
+
+    RES_ERROR,            // General error, no specific message
+
+    RES_IO_ERROR,         // Input/output operation failed
+    RES_INVALID_ARGUMENT, // Invalid argument passed to function
+    RES_NULL_POINTER,     // Null pointer passed to function
+    RES_LCOM_ERROR,       // LCOM library internal error
+} Result;
+
+/**
+ * @brief Test whether a Result value indicates success.
+ * @param result The Result code to test.
+ * @return Non-zero (true) if result == RES_OK, zero otherwise.
+ */
+#define IS_OK(result) ((result) == RES_OK)
+
+/**
+ * @brief Test whether a Result value indicates any error.
+ * @param result The Result code to test.
+ * @return Non-zero (true) if result != RES_OK, zero otherwise.
+ */
+#define IS_ERROR(result) ((result) != RES_OK)
+
+/**
+ * @brief Return immediately if a Result indicates an error.
+ * @param result The Result code to check and potentially return.
+ */
+#define RETURN_IF_ERROR(result)                          \
+    do {                                                 \
+        Result _temp_result = (result);                  \
+        if (_temp_result != RES_OK) return _temp_result; \
+    } while (0)
+
+#endif // _T_RESULT_

--- a/src/utils/result.h
+++ b/src/utils/result.h
@@ -19,6 +19,7 @@ typedef enum {
     RES_INVALID_ARGUMENT, // Invalid argument passed to function
     RES_NULL_POINTER,     // Null pointer passed to function
     RES_LCOM_ERROR,       // LCOM library internal error
+    RES_KERNEL_ERROR,     // Kernel internal error
 } Result;
 
 /**


### PR DESCRIPTION
This pull request introduces a comprehensive implementation of a timer driver for the Intel 8254 Programmable Interval Timer (PIT) and related utilities, along with integration into a lab framework (`lab2`). The changes include defining hardware-specific constants, implementing driver functions, adding utility functions for I/O operations, and creating test functions for the timer. Below is a summary of the most important changes grouped by theme.

### Timer Driver Implementation:

- **`src/drivers/timer/i8254.h`:** Added hardware-specific constants and macros for the Intel 8254 PIT, including timer channel registers, control word definitions, and mode configurations.
- **`src/drivers/timer/timer.h`:** Defined enums, typedefs, and inline functions for PIT configuration, control word assembly, and status decoding. Added function prototypes for timer operations such as configuration, frequency setting, and interrupt handling.
- **`src/drivers/timer/timer.c`:** Implemented core timer driver functions, including reading configuration, displaying configuration, setting frequency, subscribing/unsubscribing interrupts, and handling timer interrupts.

### Utility Functions:

- **`src/drivers/utils.h`:** Added utility macros and function prototypes for I/O operations (`util_sys_outb`, `util_sys_inb_alt`) and byte manipulation (`util_get_LSB_alt`, `util_get_MSB_alt`).
- **`src/drivers/utils.c`:** Implemented utility functions for safe I/O operations and extracting bytes from 16-bit values.

### Lab Integration:

- **`src/labs/Makefile`:** Configured the build process for the lab (`lab2`), specifying source files, compilation flags, and library dependencies.
- **`src/labs/lab2.c`:** Added test functions for timer operations, including reading configuration, changing frequency, and handling timer interrupts. Integrated LCF library for logging and command-line argument handling.
- **`src/labs/lab2.h`:** Declared prototypes for lab test functions (`timer_test_read_config`, `timer_test_time_base`, `timer_test_int`) to facilitate testing of timer functionality.

### Error Handling:

- **`src/utils/result.h`:** Defined the `Result` enum for standardized error codes and added macros (`IS_OK`, `IS_ERROR`, `RETURN_IF_ERROR`) for streamlined error handling.